### PR TITLE
Ensure pong messages always processed

### DIFF
--- a/index.html
+++ b/index.html
@@ -509,8 +509,6 @@
       };
       ws.onmessage = (event) => {
         let msg = JSON.parse(event.data);
-        // Ignore messages without an id or messages from our own id.
-        if (!msg.id || msg.id === playerData.id) return;
         if (msg.type === "pong") {
           latency = performance.now() - msg.timestamp;
           let status = "";
@@ -525,6 +523,8 @@
           }
           return;
         }
+        // Ignore messages without an id or messages from our own id.
+        if (!msg.id || msg.id === playerData.id) return;
         handleServerMessage(msg);
       };
       ws.onclose = () => {


### PR DESCRIPTION
## Summary
- update WebSocket onmessage handler so latency and player count updates are processed even when messages lack an id

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840ec880404833183b8a29e8f316a11