### PR TITLE
Add sanitizeHTML test and npm setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "ldawg",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node tests/sanitizeHTML.test.js"
+  }
+}

--- a/tests/sanitizeHTML.test.js
+++ b/tests/sanitizeHTML.test.js
@@ -1,0 +1,17 @@
+const assert = require('assert');
+
+function sanitizeHTML(str) {
+  if (typeof str !== 'string') return '';
+  return str.replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+}
+
+assert.strictEqual(
+  sanitizeHTML('<>&"\''),
+  '&lt;&gt;&amp;&quot;&#39;'
+);
+
+console.log('All tests passed!');


### PR DESCRIPTION
## Summary
- add Node test for sanitizeHTML function
- provide minimal `package.json` with test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840ebfc1d088331b1182baa3a4a2352