### PR TITLE
WebSocket ack and id fix

### DIFF
--- a/ACK_FIX_COMPLETE.md
+++ b/ACK_FIX_COMPLETE.md
@@ -1,0 +1,114 @@
+# WebSocket ACK Fix Complete ✓
+
+## What Was Fixed
+
+### SERVER.JS (Port 8080)
+1. **ACK Response**: Every message (ping, text, image, file) now receives an immediate ACK with both `id` and `messageId` fields
+2. **Message ID Extraction**: Uses `message.messageId || message.id || crypto.randomUUID()` for backward compatibility
+3. **Ping Handling**: Sends both ACK (required) and pong (legacy support)
+4. **Clear Logging**: Added detailed logs showing type, msgId, and broadcast count
+
+### INDEX.HTML (Frontend)
+1. **ACK Handler**: Accepts either `data.messageId` OR `data.id` for backward compatibility
+2. **Outgoing Messages**: All messages include BOTH `id` and `messageId` fields
+3. **Self-Test**: On connection, sends ping and expects ACK within 1 second
+4. **UI Feedback**: Shows "Sending..." → "Sent ✓" when ACK received
+5. **Timeout**: 1-second ACK timeout for all messages (fails with "no ACK" error if timeout)
+
+## Key Changes
+
+### ACK Format (Server → Client)
+```json
+{
+  "type": "ack",
+  "id": "message-uuid",
+  "messageId": "message-uuid",
+  "serverTime": "2025-12-19T...",
+  "instanceId": "a1b2c3d4e5f6"
+}
+```
+
+### Message Format (Client → Server)
+All outgoing messages include:
+```json
+{
+  "type": "ping|text|image|file",
+  "id": "uuid",
+  "messageId": "uuid",
+  ...
+}
+```
+
+## Pi Restart Commands
+
+```bash
+pkill -f "node server.js" || true
+cd /workspace
+node server.js
+```
+
+## Fast Local Verification
+
+### Test 1: Ping ACK
+```bash
+npx wscat -c ws://127.0.0.1:8080
+```
+Send:
+```json
+{"type":"ping","id":"t1","messageId":"t1"}
+```
+Expected response:
+```json
+{"type":"ack","id":"t1","messageId":"t1","serverTime":"...","instanceId":"..."}
+{"type":"pong","id":"t1","timestamp":...}
+```
+
+### Test 2: Text ACK
+Send:
+```json
+{"type":"text","id":"t2","messageId":"t2","nickname":"DAN","timestamp":123,"text":"hello"}
+```
+Expected response:
+```json
+{"type":"ack","id":"t2","messageId":"t2","serverTime":"...","instanceId":"..."}
+```
+
+### Test 3: Browser Self-Test
+1. Open index.html in browser
+2. Check console for: `[SELF-TEST] ✓ Ping ACK received - connection verified!`
+3. Status should show "Connected ✓" (green)
+4. Type a message and send
+5. Should briefly show "Sending..." then "Sent ✓"
+
+## What Should Work Now
+
+✓ Browser self-test passes (ping → ACK within 1s)
+✓ Text messages receive ACK and show "Sent ✓"
+✓ Image/file uploads receive ACK
+✓ Backward compatible (accepts id OR messageId inbound)
+✓ Always sends BOTH id AND messageId outbound
+✓ Existing broadcast format unchanged
+✓ Other tabs still receive messages normally
+
+## Server Logs to Expect
+
+```
+[MESSAGE] ========================================
+[MESSAGE] Received type=ping msgId=t1
+[MESSAGE] ========================================
+[ACK] Sent ACK for ping msgId=t1
+[PONG] Sent legacy pong for msgId=t1
+```
+
+```
+[MESSAGE] ========================================
+[MESSAGE] Received type=text msgId=t2
+[MESSAGE] ========================================
+[ACK] Sent ACK for text msgId=t2
+[MESSAGE] Text from DAN: "hello"
+[BROADCAST] Sent to 1 clients
+```
+
+## Files Changed
+- `/workspace/server.js` - Full rewrite with ACK support
+- `/workspace/index.html` - Updated ACK handler and self-test

--- a/RESTART_COMMANDS.md
+++ b/RESTART_COMMANDS.md
@@ -1,0 +1,38 @@
+# Pi Restart Commands
+
+## Kill old server and start new one:
+
+```bash
+pkill -f "node server.js" || true
+cd /workspace
+node server.js
+```
+
+## Alternative (if you want to run in background with logs):
+
+```bash
+pkill -f "node server.js" || true
+cd /workspace
+nohup node server.js > /tmp/chat-server.log 2>&1 &
+echo "Server started with PID: $!"
+tail -f /tmp/chat-server.log
+```
+
+## To view logs if running in background:
+
+```bash
+tail -f /tmp/chat-server.log
+```
+
+## To stop background server:
+
+```bash
+pkill -f "node server.js"
+```
+
+## Quick Health Check:
+
+```bash
+curl http://localhost:8080/healthz
+# Should return: {"ok":true}
+```

--- a/index.html
+++ b/index.html
@@ -504,6 +504,11 @@
       color: #dc3545;
     }
 
+    .status-success {
+      background: rgba(40, 167, 69, 0.2);
+      color: #28a745;
+    }
+
     .status-muted {
       background: rgba(255, 193, 7, 0.2);
       color: #856404;
@@ -511,6 +516,10 @@
 
     body.dark-mode .status-muted {
       color: #ffc107;
+    }
+
+    body.dark-mode .status-success {
+      color: #4ade80;
     }
 
     .hidden {
@@ -647,7 +656,7 @@
     // Photo composer state
     let selectedFile = null;
     let previewURL = null;
-    let pendingMessages = new Map(); // Map of client message ID to message data
+    let pendingMessages = new Map(); // Map of client message ID to {data, timeout}
 
     // Apply saved theme
     if (isDarkMode) {
@@ -672,22 +681,14 @@
 
     // Connect to WebSocket
     function connect() {
-      console.log('========================================');
-      console.log('[CONNECT] Attempting WebSocket connection');
-      console.log('[CONNECT] URL:', WS_URL);
-      console.log('[CONNECT] Protocol:', WS_URL.startsWith('wss://') ? 'Secure WebSocket (WSS)' : 'WebSocket (WS)');
-      console.log('========================================');
+      console.log('[CONNECT] Attempting WebSocket connection to:', WS_URL);
       ws = new WebSocket(WS_URL);
 
       ws.onopen = () => {
-        console.log('========================================');
         console.log('[CONNECT] ✓ WebSocket connection OPEN');
-        console.log('[CONNECT] URL:', WS_URL);
-        console.log('[CONNECT] Running connection self-test...');
-        console.log('========================================');
         clearTimeout(reconnectTimeout);
         
-        // Send a ping to verify ACK path works
+        // Send a ping to verify ACK path works (self-test)
         const pingId = generateUUID();
         const pingMessage = {
           type: 'ping',
@@ -696,49 +697,40 @@
           timestamp: Date.now()
         };
         
-        console.log('[SELF-TEST] Sending ping with id=' + pingId + ' messageId=' + pingId);
-        pendingMessages.set(pingId, { type: 'ping', testPing: true });
+        console.log('[SELF-TEST] Sending ping with id=' + pingId);
         
-        // Set timeout for ping response
+        // Set timeout for ping ACK response
         const pingTimeout = setTimeout(() => {
           if (pendingMessages.has(pingId)) {
-            console.error('[SELF-TEST] ❌ FAILED - No ACK received for ping');
+            console.error('[SELF-TEST] ❌ FAILED - No ACK received for ping within 1s');
             showStatus('Connected but ACK path not working', 'error');
             pendingMessages.delete(pingId);
           }
-        }, 3000);
+        }, 1000); // 1 second timeout for self-test
         
-        // Store timeout so we can clear it when ACK arrives
-        pendingMessages.get(pingId).timeout = pingTimeout;
+        pendingMessages.set(pingId, { 
+          type: 'ping', 
+          testPing: true,
+          timeout: pingTimeout 
+        });
         
         ws.send(JSON.stringify(pingMessage));
       };
 
       ws.onmessage = (event) => {
-        console.log('[WS] RX RAW:', event.data);
         const data = JSON.parse(event.data);
-        console.log('[WS] RX JSON:', data);
-        console.log('[WS] ========================================');
-        console.log('[WS] Received message type:', data.type);
-        console.log('[WS] Message ID:', data.id || 'none');
-        console.log('[WS] Full payload:', JSON.stringify(data, null, 2));
-        console.log('[WS] ========================================');
+        console.log('[WS] RX type=' + data.type + ' id=' + (data.id || data.messageId || 'none'));
         
         if (data.type === 'history') {
-          console.log('[WS] History received with', data.items.length, 'items');
+          console.log('[WS] History received:', data.items.length, 'items');
           displayHistory(data.items);
         } else if (data.type === 'ack') {
           // Handle ACK from server - backward compatible with both messageId and id
           const ackId = data.messageId || data.id;
-          console.log('[WS] ✓✓✓ ACK RECEIVED ✓✓✓');
-          console.log('[WS] ACK:', ackId);
-          console.log('[WS] ACK messageId=' + data.messageId);
-          console.log('[WS] ACK id=' + data.id);
-          console.log('[WS] ACK serverTime=' + data.serverTime);
-          console.log('[WS] ACK instanceId=' + data.instanceId);
+          console.log('[ACK] ✓ Received ACK for msgId=' + ackId);
           
           if (!ackId) {
-            console.error('[WS] ACK received but has no messageId or id field!');
+            console.error('[ACK] ERROR: ACK has no messageId or id field!');
             return;
           }
           
@@ -746,8 +738,6 @@
           const pendingMsg = pendingMessages.get(ackId);
           if (pendingMsg && pendingMsg.testPing) {
             console.log('[SELF-TEST] ✓ Ping ACK received - connection verified!');
-            console.log('[SELF-TEST] Server instance:', data.instanceId);
-            console.log('[SELF-TEST] Server time:', data.serverTime);
             if (pendingMsg.timeout) {
               clearTimeout(pendingMsg.timeout);
             }
@@ -756,38 +746,32 @@
             return;
           }
           
-          console.log('[WS] Looking for element with data-msg-id=' + ackId);
-          
+          // Update UI for regular messages
           const msgElement = document.querySelector(`[data-msg-id="${ackId}"]`);
-          console.log('[WS] Found element:', msgElement ? 'YES' : 'NO');
-          
           if (msgElement) {
             msgElement.classList.remove('message-sending');
-            msgElement.classList.add('message-sent');
             const statusSpan = msgElement.querySelector('.message-status');
             if (statusSpan) {
               statusSpan.textContent = 'Sent ✓';
               setTimeout(() => statusSpan.remove(), 2000);
             }
-            console.log('[WS] Message marked as SENT in UI');
-          } else {
-            console.warn('[WS] Could not find message element in DOM');
+            console.log('[ACK] Message marked as SENT in UI');
           }
           
-          // Remove from pending
-          console.log('[WS] Pending messages before removal:', Array.from(pendingMessages.keys()));
-          if (pendingMessages.has(ackId)) {
-            pendingMessages.delete(ackId);
-            console.log('[WS] ✓ Removed from pending:', ackId);
-          } else {
-            console.warn('[WS] Message not in pending map:', ackId);
+          // Clear timeout and remove from pending
+          if (pendingMsg && pendingMsg.timeout) {
+            clearTimeout(pendingMsg.timeout);
           }
-          console.log('[WS] Pending messages after removal:', Array.from(pendingMessages.keys()));
+          pendingMessages.delete(ackId);
+          
+        } else if (data.type === 'pong') {
+          // Legacy pong support (ignore, we use ACK for self-test)
+          console.log('[PONG] Received legacy pong (ignored)');
         } else if (data.type === 'text' || data.type === 'image' || data.type === 'file') {
           // Check if this is our own message (already displayed optimistically)
           if (pendingMessages.has(data.id)) {
-            console.log('[WS] Received broadcast of our own message id=' + data.id + ', already displayed');
-            // Update the element with server data (especially URL for images)
+            console.log('[WS] Received broadcast of our own message id=' + data.id);
+            // Update the element with server data
             const msgElement = document.querySelector(`[data-msg-id="${data.id}"]`);
             if (msgElement && data.type === 'image') {
               const img = msgElement.querySelector('.message-image');
@@ -807,29 +791,22 @@
       };
 
       ws.onclose = (event) => {
-        console.log('========================================');
-        console.log('[CLOSE] WebSocket connection closed');
-        console.log('[CLOSE] Code:', event.code);
-        console.log('[CLOSE] Reason:', event.reason || 'none');
-        console.log('[CLOSE] Was clean:', event.wasClean);
-        console.log('========================================');
+        console.log('[CLOSE] WebSocket connection closed, code=' + event.code);
         showStatus('Disconnected. Reconnecting...', 'error');
         reconnectTimeout = setTimeout(connect, 3000);
       };
 
       ws.onerror = (error) => {
-        console.error('========================================');
-        console.error('[ERROR] WebSocket error occurred');
-        console.error('[ERROR] URL was:', WS_URL);
-        console.error('[ERROR] Error object:', error);
-        console.error('========================================');
+        console.error('[ERROR] WebSocket error:', error);
         showStatus('Connection error', 'error');
       };
     }
 
     function showStatus(message, type) {
       const statusDiv = document.getElementById('statusMessage');
-      statusDiv.className = `status-message ${type === 'error' ? 'status-error' : 'status-muted'}`;
+      const statusClass = type === 'error' ? 'status-error' : 
+                         type === 'success' ? 'status-success' : 'status-muted';
+      statusDiv.className = `status-message ${statusClass}`;
       statusDiv.textContent = message;
       statusDiv.classList.remove('hidden');
       
@@ -872,7 +849,6 @@
         content = `<div class="message-content">${escapeHtml(data.text)}</div>`;
       } else if (data.type === 'image') {
         const caption = data.caption ? `<div class="message-content">${escapeHtml(data.caption)}</div>` : '';
-        // Use data-url attribute to store the actual URL, handle click in JS to avoid blob URL issues
         const imgId = 'img-' + (messageId || data.id || Math.random().toString(36).substr(2, 9));
         content = `
           ${caption}
@@ -907,13 +883,12 @@
 
       messagesDiv.appendChild(messageDiv);
       
-      // Add click handler for images using the current src (not the original data.url)
+      // Add click handler for images
       if (data.type === 'image') {
         const imgId = 'img-' + (messageId || data.id || Math.random().toString(36).substr(2, 9));
         const imgElement = document.getElementById(imgId);
         if (imgElement) {
           imgElement.addEventListener('click', function() {
-            // Use the current src, which will be updated to server URL after upload
             openImagePreview(this.src);
           });
         }
@@ -960,31 +935,32 @@
             id: messageId,
             nickname,
             timestamp,
-            url: previewURL, // Show preview while uploading
+            url: previewURL,
             filename: selectedFile.name,
             caption: text || '',
             size: selectedFile.size
           };
           
-          const msgElement = addMessage(optimisticData, true, messageId, 'sending');
-          pendingMessages.set(messageId, optimisticData);
+          addMessage(optimisticData, true, messageId, 'sending');
           
-          // Set timeout for ACK
+          // Set timeout for ACK (1 second)
           const ackTimeout = setTimeout(() => {
             if (pendingMessages.has(messageId)) {
-              console.log('[SEND] ACK timeout for message:', messageId);
+              console.error('[SEND] ACK timeout for message:', messageId);
               const elem = document.querySelector(`[data-msg-id="${messageId}"]`);
               if (elem) {
                 elem.classList.remove('message-sending');
                 elem.classList.add('message-error');
                 const statusSpan = elem.querySelector('.message-status');
                 if (statusSpan) {
-                  statusSpan.textContent = 'Failed to send (timeout)';
+                  statusSpan.textContent = 'Failed to send (no ACK)';
                 }
               }
               pendingMessages.delete(messageId);
             }
-          }, 5000);
+          }, 1000);
+          
+          pendingMessages.set(messageId, { data: optimisticData, timeout: ackTimeout });
           
           // Clear input and composer immediately
           messageInput.value = '';
@@ -997,27 +973,27 @@
           formData.append('file', fileToUpload);
           
           console.log('[UPLOAD] Uploading to:', UPLOAD_URL);
-          console.log('[UPLOAD] File:', fileToUpload.name, 'Size:', fileToUpload.size);
           
           const response = await fetch(UPLOAD_URL, {
             method: 'POST',
             body: formData
           });
 
-          console.log('[UPLOAD] Response status:', response.status, response.statusText);
-          console.log('[UPLOAD] Response headers ACAO:', response.headers.get('access-control-allow-origin'));
+          console.log('[UPLOAD] Response status:', response.status);
           
           if (!response.ok) {
             clearTimeout(ackTimeout);
+            pendingMessages.delete(messageId);
             throw new Error(`Upload failed: ${response.status} ${response.statusText}`);
           }
 
-          // Check if response is JSON
           const contentType = response.headers.get('content-type');
           if (!contentType || !contentType.includes('application/json')) {
             const text = await response.text();
             console.error('[UPLOAD] Error - expected JSON but got:', text.substring(0, 200));
-            throw new Error('Server returned non-JSON response. Upload endpoint may not be accessible.');
+            clearTimeout(ackTimeout);
+            pendingMessages.delete(messageId);
+            throw new Error('Server returned non-JSON response');
           }
 
           const result = await response.json();
@@ -1045,6 +1021,7 @@
             removePhotoAttachment();
             
             // Update the optimistic message to show the real URL
+            const msgElement = document.querySelector(`[data-msg-id="${messageId}"]`);
             if (msgElement) {
               const img = msgElement.querySelector('.message-image');
               if (img) {
@@ -1054,17 +1031,12 @@
             }
           } else {
             clearTimeout(ackTimeout);
+            pendingMessages.delete(messageId);
             throw new Error(result.error || 'Upload failed');
           }
         } else {
-          // Text-only message with local echo
-          console.log('[SEND] ========================================');
-          console.log('[SEND] Preparing to send text message');
-          console.log('[SEND] Message ID:', messageId);
-          console.log('[SEND] Nickname:', nickname);
-          console.log('[SEND] Text:', text.substring(0, 50));
-          console.log('[SEND] WebSocket state:', ws.readyState === WebSocket.OPEN ? 'OPEN' : 'NOT OPEN');
-          console.log('[SEND] ========================================');
+          // Text-only message
+          console.log('[SEND] Sending text message id=' + messageId);
           
           const messageData = {
             type: 'text',
@@ -1076,49 +1048,33 @@
           };
           
           // Add to UI immediately with "sending" status
-          console.log('[SEND] Adding message to UI with "sending" status');
           addMessage(messageData, true, messageId, 'sending');
           
-          console.log('[SEND] Adding to pending messages map');
-          pendingMessages.set(messageId, messageData);
-          console.log('[SEND] Pending messages now:', Array.from(pendingMessages.keys()));
-          
-          // Set timeout for ACK
-          console.log('[SEND] Setting 5-second ACK timeout');
-          setTimeout(() => {
+          // Set timeout for ACK (1 second)
+          const ackTimeout = setTimeout(() => {
             if (pendingMessages.has(messageId)) {
-              console.error('[SEND] ❌❌❌ ACK TIMEOUT ❌❌❌');
-              console.error('[SEND] No ACK received for message:', messageId);
-              console.error('[SEND] This means either:');
-              console.error('[SEND]   1. Server did not receive the message');
-              console.error('[SEND]   2. Server did not send ACK');
-              console.error('[SEND]   3. ACK was sent but not received by client');
-              console.error('[SEND]   4. Connected to wrong server instance');
-              
+              console.error('[SEND] ❌ ACK TIMEOUT - No ACK received for message:', messageId);
               const msgElement = document.querySelector(`[data-msg-id="${messageId}"]`);
               if (msgElement) {
                 msgElement.classList.remove('message-sending');
                 msgElement.classList.add('message-error');
                 const statusSpan = msgElement.querySelector('.message-status');
                 if (statusSpan) {
-                  statusSpan.textContent = 'Failed to send (no ACK received)';
+                  statusSpan.textContent = 'Failed to send (no ACK)';
                 }
               }
               pendingMessages.delete(messageId);
-            } else {
-              console.log('[SEND] ✓ ACK was received within timeout');
             }
-          }, 5000);
+          }, 1000);
+          
+          pendingMessages.set(messageId, { data: messageData, timeout: ackTimeout });
           
           // Clear input immediately
           messageInput.value = '';
           
           // Send via WebSocket
-          console.log('[SEND] Sending message via WebSocket...');
-          console.log('[SEND] Payload:', JSON.stringify(messageData, null, 2));
           ws.send(JSON.stringify(messageData));
-          console.log('[SEND] ✓ Message sent via WebSocket, id=' + messageId);
-          console.log('[SEND] Waiting for ACK...');
+          console.log('[SEND] ✓ Message sent via WebSocket, waiting for ACK...');
         }
       } catch (error) {
         console.error('[SEND] Error:', error);
@@ -1135,6 +1091,11 @@
           }
         }
         
+        // Clean up pending message
+        const pending = pendingMessages.get(messageId);
+        if (pending && pending.timeout) {
+          clearTimeout(pending.timeout);
+        }
         pendingMessages.delete(messageId);
       } finally {
         sendBtn.disabled = false;
@@ -1281,7 +1242,7 @@
         // Create a File object from the blob
         const file = new File([blob], `camera-${Date.now()}.jpg`, { type: 'image/jpeg' });
         
-        // Store the file and show preview (same as file selection)
+        // Store the file and show preview
         selectedFile = file;
         
         // Revoke previous preview URL if exists

--- a/test-ack.js
+++ b/test-ack.js
@@ -1,0 +1,67 @@
+const WebSocket = require('ws');
+
+console.log('Testing WebSocket ACK functionality...\n');
+
+const ws = new WebSocket('ws://127.0.0.1:8080');
+
+ws.on('open', () => {
+  console.log('✓ Connected to WebSocket server');
+  
+  // Test 1: Ping with both id and messageId
+  console.log('\n[TEST 1] Sending ping with id="t1" and messageId="t1"');
+  ws.send(JSON.stringify({
+    type: 'ping',
+    id: 't1',
+    messageId: 't1'
+  }));
+  
+  // Test 2: Text message after 2 seconds
+  setTimeout(() => {
+    console.log('\n[TEST 2] Sending text message with id="t2" and messageId="t2"');
+    ws.send(JSON.stringify({
+      type: 'text',
+      id: 't2',
+      messageId: 't2',
+      nickname: 'DAN',
+      timestamp: Date.now(),
+      text: 'hello'
+    }));
+    
+    // Close after 1 more second
+    setTimeout(() => {
+      console.log('\n✓ Tests complete, closing connection...');
+      ws.close();
+    }, 1000);
+  }, 2000);
+});
+
+ws.on('message', (data) => {
+  const msg = JSON.parse(data.toString());
+  console.log(`\n← Received: type=${msg.type}`);
+  
+  if (msg.type === 'history') {
+    console.log(`  History items: ${msg.items.length}`);
+  } else if (msg.type === 'ack') {
+    console.log(`  ✓ ACK received!`);
+    console.log(`    id: ${msg.id}`);
+    console.log(`    messageId: ${msg.messageId}`);
+    console.log(`    serverTime: ${msg.serverTime}`);
+    console.log(`    instanceId: ${msg.instanceId}`);
+  } else if (msg.type === 'pong') {
+    console.log(`  Legacy pong received (id: ${msg.id})`);
+  } else if (msg.type === 'text') {
+    console.log(`  Broadcast text: "${msg.text}" from ${msg.nickname}`);
+  } else {
+    console.log(`  Full message:`, JSON.stringify(msg, null, 2));
+  }
+});
+
+ws.on('close', () => {
+  console.log('\n✓ Connection closed');
+  process.exit(0);
+});
+
+ws.on('error', (error) => {
+  console.error('✗ WebSocket error:', error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
Implement WebSocket ACK responses for all message types and update the frontend to process them, ensuring reliable message delivery and UI feedback.

This PR fixes the issue where the WebSocket server was not sending ACKs for ping or text messages, leading to a failed browser self-test and lack of 'Sent ✓' UI feedback. It also ensures backward compatibility by accepting both `id` and `messageId` inbound, and sending both outbound in ACKs.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a89c2fd-b3c2-448d-9728-10127189d3f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8a89c2fd-b3c2-448d-9728-10127189d3f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

