### PR TITLE
Pi global regressions fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -1605,8 +1605,8 @@
     let clientToken = getOrCreateToken();
     console.log('[TOKEN] Using client token:', clientToken);
 
-    // WebSocket configuration
-    const WS_URL = `wss://ws.ldawg7624.com?token=${encodeURIComponent(clientToken)}`;
+    // WebSocket configuration (base URL, will be constructed in connect())
+    const WS_BASE_URL = 'wss://ws.ldawg7624.com';
     
     // Upload configuration
     const UPLOAD_URL = 'https://upload.ldawg7624.com/upload';
@@ -1620,7 +1620,21 @@
     }
 
     function setCookie(name, value, maxAgeSeconds) {
-      document.cookie = `${name}=${value}; path=/; max-age=${maxAgeSeconds}; SameSite=Lax; Secure`;
+      // Set domain to ensure cookies are sent with WebSocket connections across subdomains
+      // Extract base domain (e.g., ldawg7624.com from www.ldawg7624.com or ws.ldawg7624.com)
+      const hostname = window.location.hostname;
+      let domain = '';
+      
+      // Only set domain if not localhost (for cross-subdomain cookie sharing)
+      if (hostname !== 'localhost' && hostname !== '127.0.0.1') {
+        // Extract base domain (last two parts of hostname)
+        const parts = hostname.split('.');
+        if (parts.length >= 2) {
+          domain = `; domain=.${parts.slice(-2).join('.')}`;
+        }
+      }
+      
+      document.cookie = `${name}=${value}; path=/; max-age=${maxAgeSeconds}; SameSite=Lax; Secure${domain}`;
     }
     
     // Profanity state management
@@ -2196,12 +2210,19 @@
     // ========================================
     
     function connect() {
+      // Construct WebSocket URL with token and preserved clientId if it exists
+      let wsUrl = `${WS_BASE_URL}?token=${encodeURIComponent(clientToken)}`;
+      if (myClientId) {
+        wsUrl += `&clientId=${encodeURIComponent(myClientId)}`;
+      }
+      
       console.log('========================================');
       console.log('[CONNECT] Attempting WebSocket connection');
-      console.log('[CONNECT] URL:', WS_URL);
+      console.log('[CONNECT] URL:', wsUrl);
       console.log('[CONNECT] Token:', clientToken);
+      console.log('[CONNECT] myClientId:', myClientId || '(none - will get new one)');
       console.log('========================================');
-      ws = new WebSocket(WS_URL);
+      ws = new WebSocket(wsUrl);
 
       ws.onopen = () => {
         console.log('========================================');


### PR DESCRIPTION
Fixes strike count resetting on reload and restores green styling for own messages.

The strike count regression occurred because cookies were not correctly scoped for cross-subdomain WebSocket connections, and the server didn't always use the highest strike count from the cookie. The green message regression was due to the server generating a new `clientId` on each WebSocket connection, causing the client's stored `myClientId` to no longer match the `senderId` of its messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5a2459e-b60e-445c-b1f6-4c24642cc6d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d5a2459e-b60e-445c-b1f6-4c24642cc6d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

