### PR TITLE
Admin mute notification system

### DIFF
--- a/ADMIN_MUTE_NOTIFICATION_IMPLEMENTATION.md
+++ b/ADMIN_MUTE_NOTIFICATION_IMPLEMENTATION.md
@@ -1,0 +1,88 @@
+# Admin Mute Notification System - Implementation Summary
+
+## Overview
+When an admin mutes/bans a user, the muted user now immediately sees a visible notice message in their chat feed.
+
+## Changes Made
+
+### 1. Server-Side (`apps/pi-global/server.js`)
+
+#### Added Duration Formatting Function
+- **Location**: Lines 59-75
+- **Function**: `formatDurationLabel(durationMs)`
+- **Purpose**: Converts milliseconds to human-readable labels
+- **Examples**:
+  - 30000ms → "30 seconds"
+  - 60000ms → "1 minute"
+  - 600000ms → "10 minutes"
+  - 86400000ms → "1 day"
+
+#### Updated Admin Ban Handler
+- **Location**: Lines 980-1002
+- **Changes**: After applying the mute, the server now:
+  1. Calculates the duration label using `formatDurationLabel()`
+  2. Sends the existing `admin_mute` event (for status bar and input disabling)
+  3. **NEW**: Sends a `system` message to the muted user's chat feed:
+     ```json
+     {
+       "type": "system",
+       "text": "Admin muted you for ${durationLabel}",
+       "timestamp": 1234567890
+     }
+     ```
+
+### 2. Client-Side (`index.html`)
+
+#### Added System Message Handler
+- **Location**: Lines 3490-3492
+- **Handler**: Catches `type: 'system'` messages
+- **Action**: Calls `addSystemMessage(data.text, 'warning')` to display in chat feed
+- **Styling**: Uses existing system message styling (red background, centered, etc.)
+
+## What Was NOT Changed
+
+✅ Mute logic remains unchanged  
+✅ Database logic remains unchanged  
+✅ UI styling remains unchanged (reuses existing `addSystemMessage` function)  
+✅ All existing admin mute functionality preserved  
+
+## How It Works
+
+1. **Admin mutes a user** (via admin panel)
+2. **Server applies the mute** (existing logic)
+3. **Server sends TWO messages to the muted user**:
+   - `admin_mute` event → Updates status bar and disables input
+   - `system` message → **NEW** Adds visible notice to chat feed
+4. **User immediately sees**:
+   - Status bar: "Muted by admin for X seconds"
+   - **Chat feed: "Admin muted you for X"** ← NEW FEATURE
+
+## Testing
+
+To verify the implementation:
+
+1. Open chat as a regular user
+2. Send a message
+3. As admin, click the mute button on that message (select a duration)
+4. **Expected result**: The muted user should immediately see:
+   - A red system message in the chat feed: "Admin muted you for [duration]"
+   - The status bar message (existing behavior)
+   - Input disabled (existing behavior)
+
+## Duration Format Examples
+
+| Duration (ms) | Display Label |
+|--------------|--------------|
+| 30,000 | "30 seconds" |
+| 60,000 | "1 minute" |
+| 120,000 | "2 minutes" |
+| 600,000 | "10 minutes" |
+| 3,600,000 | "1 hour" |
+| 86,400,000 | "1 day" |
+
+## Technical Notes
+
+- Message is sent ONLY to the muted user (targeted websocket send)
+- Message appears immediately (no page reload required)
+- Uses existing `addSystemMessage()` function (no new UI code)
+- Fully compatible with existing admin mute system

--- a/index.html
+++ b/index.html
@@ -3487,6 +3487,9 @@
           const messagesDiv = document.getElementById('messages');
           messagesDiv.innerHTML = '';
           showToast('All messages have been deleted by ' + data.wipedBy, 'error');
+        } else if (data.type === 'system') {
+          // System message (e.g., admin mute notification)
+          addSystemMessage(data.text || 'System notification', 'warning');
         } else if (data.type === 'admin_delete_success') {
           showToast('Message deleted', 'success');
         } else if (data.type === 'admin_ban_success') {


### PR DESCRIPTION
Display an immediate system message in the chat feed to users when they are muted by an admin.

---
<a href="https://cursor.com/background-agent?bcId=bc-40b42b65-a8fd-4196-81ff-3997467b2c78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-40b42b65-a8fd-4196-81ff-3997467b2c78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

