### PR TITLE
Admin mute notification fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -3202,6 +3202,13 @@
         console.log('[WS] RX:', event.data);
         const data = JSON.parse(event.data);
         
+        // CRITICAL: Handle system messages FIRST (admin mute notifications, etc.)
+        // These must display even for muted users
+        if (data.type === 'system') {
+          addSystemMessage(data.text || 'System notification', 'warning');
+          // Continue processing other message types if needed
+        }
+        
         if (data.type === 'welcome') {
           // If we already have a session clientId, keep using it (for ownership persistence)
           // Otherwise, accept the new one from the server
@@ -3487,9 +3494,6 @@
           const messagesDiv = document.getElementById('messages');
           messagesDiv.innerHTML = '';
           showToast('All messages have been deleted by ' + data.wipedBy, 'error');
-        } else if (data.type === 'system') {
-          // System message (e.g., admin mute notification)
-          addSystemMessage(data.text || 'System notification', 'warning');
         } else if (data.type === 'admin_delete_success') {
           showToast('Message deleted', 'success');
         } else if (data.type === 'admin_ban_success') {


### PR DESCRIPTION
Restore admin mute/ban functionality and ensure immediate display of mute notifications to fix a regression.

The previous changes to mute notification broke the functionality and prevented the "Admin muted you for X" message from showing. This PR re-implements the notification delivery on the server using a new helper and prioritizes system message handling on the client to ensure immediate display for muted users.

---
<a href="https://cursor.com/background-agent?bcId=bc-be880343-418b-44ab-afaf-116071cbafd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-be880343-418b-44ab-afaf-116071cbafd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

